### PR TITLE
README: warn of dangers of named constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ var MyChild = ClassX.extend( MyClass, function(base) {
 });
 ```
 
+Caution: `this.constructor.name` is [experimental](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name) and will likely fail in some web browsers. Additionally, [minification may mangle `this.constructor.name`](https://github.com/jashkenas/coffeescript/issues/2052).
+
 The ``extend`` function passes the base class as an argument to the ``extensions``
 function. To access the base class, either provide a named argument, or
 use the JavaScript ``arguments[0]`` array.


### PR DESCRIPTION
Might help other folks avoid the same mistake I did. I'm not sure I love the wording or placement, but it's a start. What do you think, Chris?

See also:
* http://stackoverflow.com/questions/332422/how-do-i-get-the-name-of-an-objects-type-in-javascript#comment19454004_332429
* https://github.com/jashkenas/coffeescript/issues/2052
* http://code.dblock.org/2012/10/13/how-do-i-get-the-name-of-an-objects-type-in-javascript.html
* https://github.com/arsnebula/classx/issues/1
* https://github.com/meonkeys/classx-2-0-3-minification-bug